### PR TITLE
Upgrade to ubl 2.1

### DIFF
--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -13,7 +13,7 @@ use Sabre\Xml\Writer;
 use Sabre\Xml\XmlSerializable;
 
 class Invoice implements XmlSerializable{
-    private $UBLVersionID = '2.0';
+    private $UBLVersionID = '2.2';
 
     /**
      * @var int

--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -13,7 +13,7 @@ use Sabre\Xml\Writer;
 use Sabre\Xml\XmlSerializable;
 
 class Invoice implements XmlSerializable{
-    private $UBLVersionID = '2.2';
+    private $UBLVersionID = '2.1';
 
     /**
      * @var int

--- a/tests/ubl.xml
+++ b/tests/ubl.xml
@@ -2,7 +2,7 @@
 <Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
          xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
          xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2">
-    <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
+    <cbc:UBLVersionID>2.2</cbc:UBLVersionID>
     <cbc:CustomizationID>OIOUBL-2.01</cbc:CustomizationID>
     <cbc:ID>CIT1234</cbc:ID>
     <cbc:CopyIndicator>false</cbc:CopyIndicator>

--- a/tests/ubl.xml
+++ b/tests/ubl.xml
@@ -2,7 +2,7 @@
 <Invoice xmlns="urn:oasis:names:specification:ubl:schema:xsd:Invoice-2"
          xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
          xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2">
-    <cbc:UBLVersionID>2.2</cbc:UBLVersionID>
+    <cbc:UBLVersionID>2.1</cbc:UBLVersionID>
     <cbc:CustomizationID>OIOUBL-2.01</cbc:CustomizationID>
     <cbc:ID>CIT1234</cbc:ID>
     <cbc:CopyIndicator>false</cbc:CopyIndicator>


### PR DESCRIPTION
Upgrade version number to 2.1. UBL 2.1 and UBL 2.2 are backwards compatible so no changes are required. However the UBL validator we are using for our tests do not support UBL 2.2 yet.